### PR TITLE
remove thousands separator

### DIFF
--- a/bin/chartHzDiagnostics
+++ b/bin/chartHzDiagnostics
@@ -25,7 +25,7 @@ while read -r line; do
    for f in "${fields[@]}"; do
     echo $f
     #ls diagnostics* | sort | xargs -n 1 grep  ${f} >> $f.txt
-    grep ${f} diagnostics* > $f.txt
+    grep ${f} diagnostics* | tr -d ',' > $f.txt
 
    done
   cd ${currentDir}


### PR DESCRIPTION
comma is used as a thousands separator in some locale. we do not want to have it in gnuplot input files